### PR TITLE
Regularized H-Score and TransRate

### DIFF
--- a/tllib/ranking/hscore.py
+++ b/tllib/ranking/hscore.py
@@ -3,6 +3,7 @@
 @contact: liuyong1095556447@163.com
 """
 import numpy as np
+from sklearn.covariance import LedoitWolf
 
 __all__ = ['h_score']
 
@@ -44,4 +45,43 @@ def h_score(features: np.ndarray, labels: np.ndarray):
 
     return score
 
+def regularized_h_score(features: np.ndarray, labels: np.ndarray):
+        r"""
+    Newer is not always better: Rethinking transferability metrics, their peculiarities, stability and performance (NeurIPS 2021) 
+    <https://openreview.net/pdf?id=iz_Wwmfquno>`_.
+    
+    The  regularized H-Score :math:`\mathcal{H}_{\alpha}` can be described as:
 
+    .. math::
+        \mathcal{H}_{\alpha}=\operatorname{tr}\left(\operatorname{cov}_{\alpha}(f)^{-1} (1 - \alpha) \operatorname{cov}\left(\mathbb{E}[f \mid y]\right)\right)
+    
+    where :math:`f` is the features extracted by the model to be ranked, :math:`y` is the groud-truth label vector and :math:`\operatorname{cov}_{\alpha}` the  Ledoit-Wolf 
+    covariance estimator with shrinkage parameter :math:`\alpha`
+    Args:
+        features (np.ndarray):features extracted by pre-trained model.
+        labels (np.ndarray):  groud-truth labels.
+
+    Shape:
+        - features: (N, F), with number of samples N and feature dimension F.
+        - labels: (N, ) elements in [0, :math:`C_t`), with target class number :math:`C_t`.
+        - score: scalar.
+    """
+    f = features.astype('float64')
+    f = f - np.mean(f, axis= 0, keepdims= True) #Center the features for correct Ledoit-Wolf Estimation
+    y = labels
+
+    C = int(y.max() + 1)
+    g = np.zeros_like(f)
+
+    cov = LedoitWolf(assume_centered= False).fit(f)
+    alpha = cov.shrinkage_
+    covf_alpha = cov.covariance_
+
+    for i in range(C):
+        Ef_i = np.mean(f[y == i, :], axis=0)
+        g[y == i] = Ef_i
+
+    covg = np.cov(g, rowvar = False)
+    score = np.trace(np.dot(np.linalg.pinv(covf_alpha, rcond=1e-15), (1-alpha) * covg))
+
+    return score

--- a/tllib/ranking/hscore.py
+++ b/tllib/ranking/hscore.py
@@ -47,7 +47,7 @@ def h_score(features: np.ndarray, labels: np.ndarray):
 
 def regularized_h_score(features: np.ndarray, labels: np.ndarray):
         r"""
-    Newer is not always better: Rethinking transferability metrics, their peculiarities, stability and performance (NeurIPS 2021) 
+    Regularized H-score in `Newer is not always better: Rethinking transferability metrics, their peculiarities, stability and performance (NeurIPS 2021) 
     <https://openreview.net/pdf?id=iz_Wwmfquno>`_.
     
     The  regularized H-Score :math:`\mathcal{H}_{\alpha}` can be described as:

--- a/tllib/ranking/hscore.py
+++ b/tllib/ranking/hscore.py
@@ -5,7 +5,7 @@
 import numpy as np
 from sklearn.covariance import LedoitWolf
 
-__all__ = ['h_score']
+__all__ = ['h_score', 'regularized_h_score']
 
 
 def h_score(features: np.ndarray, labels: np.ndarray):
@@ -53,7 +53,7 @@ def regularized_h_score(features: np.ndarray, labels: np.ndarray):
     The  regularized H-Score :math:`\mathcal{H}_{\alpha}` can be described as:
 
     .. math::
-        \mathcal{H}_{\alpha}=\operatorname{tr}\left(\operatorname{cov}_{\alpha}(f)^{-1} (1 - \alpha) \operatorname{cov}\left(\mathbb{E}[f \mid y]\right)\right)
+        \mathcal{H}_{\alpha}=\operatorname{tr}\left(\operatorname{cov}_{\alpha}(f)^{-1}\left(1-\alpha \right)\operatorname{cov}\left(\mathbb{E}[f \mid y]\right)\right)
     
     where :math:`f` is the features extracted by the model to be ranked, :math:`y` is the groud-truth label vector and :math:`\operatorname{cov}_{\alpha}` the  Ledoit-Wolf 
     covariance estimator with shrinkage parameter :math:`\alpha`

--- a/tllib/ranking/hscore.py
+++ b/tllib/ranking/hscore.py
@@ -31,12 +31,7 @@ def h_score(features: np.ndarray, labels: np.ndarray):
     f = features
     y = labels
 
-    def covariance(X):
-        X_mean = X - np.mean(X, axis=0, keepdims=True)
-        cov = np.divide(np.dot(X_mean.T, X_mean), len(X) - 1)
-        return cov
-
-    covf = covariance(f)
+    covf = np.cov(f, rowvar = False)
     C = int(y.max() + 1)
     g = np.zeros_like(f)
 
@@ -44,7 +39,9 @@ def h_score(features: np.ndarray, labels: np.ndarray):
         Ef_i = np.mean(f[y == i, :], axis=0)
         g[y == i] = Ef_i
 
-    covg = covariance(g)
+    covg = np.cov(g, rowvar = False)
     score = np.trace(np.dot(np.linalg.pinv(covf, rcond=1e-15), covg))
 
     return score
+
+

--- a/tllib/ranking/transrate.py
+++ b/tllib/ranking/transrate.py
@@ -1,0 +1,49 @@
+"""
+@author: Louis Fouquet
+@contact: louisfouquet75@gmail.com
+"""
+import numpy as np
+
+
+__all__ = ['transrate']
+
+def coding_rate(features : np.ndarray, eps = 1e-4):
+    f = features
+    n, d = f.shape
+    (_, rate) = np.linalg.slogdet((np.eye(d) + 1 / (n * eps) * f.transpose() @ f))
+    return 0.5 * rate
+
+
+def transrate(features: np.ndarray, labels: np.ndarray, eps = 1e-4):
+    r"""
+    TransRate in `Frustratingly easy transferability estimation (ICML 2022) 
+    <https://proceedings.mlr.press/v162/huang22d/huang22d.pdf>`_.
+    
+    The TransRate :math:`TrR` can be described as:
+
+    .. math::
+        TrR= R\left(f, \espilon \right) - R\left(f, \espilon \mid y \right) 
+    
+    where :math:`f` is the features extracted by the model to be ranked, :math:`y` is the groud-truth label vector, 
+    :math:`R` is the coding rate with distortion rate :math:`\epsilon`
+
+    Args:
+        features (np.ndarray):features extracted by pre-trained model.
+        labels (np.ndarray):  groud-truth labels.
+        eps (float, optional): distortion rare (Default: 1e-4)
+
+    Shape:
+        - features: (N, F), with number of samples N and feature dimension F.
+        - labels: (N, ) elements in [0, :math:`C_t`), with target class number :math:`C_t`.
+        - score: scalar.
+    """
+    f = features
+    y = labels
+    f = f - np.mean(f, axis = 0, keepdims = True)
+    Rf = coding_rate(f, eps)
+    Rfy = 0.0
+    C = int(y.max() + 1)
+    for i in range(C):
+        Rfy += coding_rate(f[(y==i).flatten()], eps)
+    return Rf - Rfy / C
+


### PR DESCRIPTION
I added two recent transferability metrics : 
- An improved version of H-Score using LedoitWolf covariance estimator from [Newer is not always better: Rethinking transferability metrics, their peculiarities, stability and performance](https://arxiv.org/abs/2110.06893)
- TransRate from [Frustratingly easy transferability estimation](https://proceedings.mlr.press/v162/huang22d.html)

I also replaced the manual computation of covariance by the numpy version which is much faster.
I added the regularized H_score to the H-Score scipt but I can make two different scripts